### PR TITLE
Pin libxml to 0.3.3 because 0.3.4 is breaking interface ...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ flate2 = "1.0"
 snafu = "0.7"
 rand = "0.8.4"
 derive_builder = "0.11.2"
-libxml = { version = "0.3.0", optional = true}
+libxml = { version = "=0.3.3", optional = true }
 uuid = { version = ">=0.8.0, <2.0.0", features = [ "v4" ] }
 data-encoding = "2.2.0"
 libc        = {version = "^0.2.66", optional = true}


### PR DESCRIPTION
and we can't afford currently to move forward with our fork.